### PR TITLE
Add MCP tool for team library components

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,9 +187,12 @@ The MCP server provides the following tools for interacting with Figma:
 
 - `get_styles` - Get information about local styles
 - `get_local_components` - Get information about local components
-- `create_component_instance` - Create an instance of a component
+- `get_team_components` - Discover published components from enabled team libraries with optional filters for library or component set metadata
+- `create_component_instance` - Create an instance of a component. Supply a `componentKey` from `get_local_components` (local assets) or `get_team_components` (published libraries) before invoking this tool
 - `get_instance_overrides` - Extract override properties from a selected component instance
 - `set_instance_overrides` - Apply extracted overrides to target instances
+
+When you need to instantiate a component stored in a shared library, run `get_team_components` to retrieve its `key` (optionally filtering by library or component set). With that key and the library enabled in your Figma document, call `create_component_instance` to import the remote component into the canvas.
 
 ### Export & Advanced
 

--- a/src/cursor_mcp_plugin/manifest.json
+++ b/src/cursor_mcp_plugin/manifest.json
@@ -8,7 +8,9 @@
     "figma",
     "figjam"
   ],
-  "permissions": [],
+  "permissions": [
+    "teamLibrary"
+  ],
   "networkAccess": {
     "allowedDomains": [
       "https://google.com"

--- a/src/talk_to_figma_mcp/server.ts
+++ b/src/talk_to_figma_mcp/server.ts
@@ -998,6 +998,62 @@ server.tool(
   }
 );
 
+// Get Team Components Tool
+server.tool(
+  "get_team_components",
+  "List published components available from enabled team libraries. Use this to discover remote component keys before importing instances.",
+  {
+    libraryId: z
+      .string()
+      .optional()
+      .describe("Filter to components published by the library with this ID."),
+    libraryName: z
+      .string()
+      .optional()
+      .describe("Filter to libraries whose name matches this value (case-insensitive)."),
+    componentSetKey: z
+      .string()
+      .optional()
+      .describe("Filter to components that belong to a specific component set key."),
+  },
+  async ({ libraryId, libraryName, componentSetKey }: any = {}) => {
+    try {
+      const result = await sendCommandToFigma("get_team_components", {
+        libraryId,
+        libraryName,
+        componentSetKey,
+      });
+
+      const documentation = [
+        "Response structure:",
+        "- count: Total number of matching published components.",
+        "- components: Array of metadata with key, name, description, componentSetKey, libraryId, libraryName, and documentationLinks.",
+        "Use the component key with create_component_instance to import remote instances once the library is enabled in Figma.",
+      ].join("\n");
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `${documentation}\n\n${JSON.stringify(result, null, 2)}`,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Error getting team components: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+      };
+    }
+  }
+);
+
 // Get Annotations Tool
 server.tool(
   "get_annotations",
@@ -2631,6 +2687,7 @@ type FigmaCommand =
   | "delete_multiple_nodes"
   | "get_styles"
   | "get_local_components"
+  | "get_team_components"
   | "create_component_instance"
   | "get_instance_overrides"
   | "set_instance_overrides"
@@ -2723,7 +2780,11 @@ type CommandParams = {
   };
   get_styles: Record<string, never>;
   get_local_components: Record<string, never>;
-  get_team_components: Record<string, never>;
+  get_team_components: {
+    libraryId?: string;
+    libraryName?: string;
+    componentSetKey?: string;
+  };
   create_component_instance: {
     componentKey: string;
     x: number;


### PR DESCRIPTION
## Summary
- grant the Figma plugin teamLibrary permission and implement a getTeamComponents helper that surfaces key metadata with optional filtering
- expose a get_team_components MCP tool, route the command through the plugin, and document how to fetch remote component keys before instancing them

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68cac76d1d148330af8aa7291ff1f351