### PR TITLE
Remove deprecated teamLibrary permission from plugin manifest

### DIFF
--- a/src/cursor_mcp_plugin/manifest.json
+++ b/src/cursor_mcp_plugin/manifest.json
@@ -8,9 +8,6 @@
     "figma",
     "figjam"
   ],
-  "permissions": [
-    "teamLibrary"
-  ],
   "networkAccess": {
     "allowedDomains": [
       "https://google.com"


### PR DESCRIPTION
## Summary
- remove the deprecated teamLibrary permission from the cursor MCP plugin manifest to align with current Figma requirements

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68cadac1b93083309590c25b31abe5ae