### PR TITLE
Add team library permission to manifest

### DIFF
--- a/src/cursor_mcp_plugin/manifest.json
+++ b/src/cursor_mcp_plugin/manifest.json
@@ -19,5 +19,8 @@
   },
   "documentAccess": "dynamic-page",
   "enableProposedApi": true,
-  "enablePrivatePluginApi": true
+  "enablePrivatePluginApi": true,
+  "permissions": [
+    "teamLibrary"
+  ]
 }


### PR DESCRIPTION
## Summary
- add a permissions array to the plugin manifest
- request access to figma.teamLibrary APIs for development and community builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cadfb2bf4083308fac38b88da12b0a