### PR TITLE
Configure Vite bundler to exclude MCP server modules

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const externalPackages = [
+  '@modelcontextprotocol/sdk',
+  '@modelcontextprotocol/nodes',
+];
+
+const serverModuleRelative = 'src/talk_to_figma_mcp/server.ts';
+const serverModuleAbsolute = path.resolve(__dirname, serverModuleRelative);
+
+export default defineConfig({
+  optimizeDeps: {
+    exclude: [...externalPackages, serverModuleRelative],
+  },
+  build: {
+    rollupOptions: {
+      external: [...externalPackages, serverModuleRelative, serverModuleAbsolute],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite configuration that keeps the MCP server entry point and SDK packages external to the client bundle

## Testing
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68cb08a136bc833090fc6b9eb85aecfe